### PR TITLE
mysql check shouldnt connect on init

### DIFF
--- a/lib/simple_health_check/mysql_check.rb
+++ b/lib/simple_health_check/mysql_check.rb
@@ -3,7 +3,7 @@ class SimpleHealthCheck::MysqlCheck < SimpleHealthCheck::BaseNoProc
     @service_name = service_name
     @proc = check_proc || SimpleHealthCheck::Configuration.mysql_check_proc
     @type = 'internal'
-    @version = version_check || nil
+    @version = version_check rescue nil
   end
 
   def call(response:)

--- a/lib/simple_health_check/version.rb
+++ b/lib/simple_health_check/version.rb
@@ -1,3 +1,3 @@
 module SimpleHealthCheck
-  VERSION = '0.1.0'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
Mysql Health check initializer tries to connect to mysql. When running this in dockerized apps, there are commands like assets:precompile and db:setup that can potentially run before mysql is up, or the database exists. Since this is called in a rails initializer, this raises an exception and kills the rake task. Resque this call to version_check in the init function so that if we can connect fine, if we can't, fine

- [x] @ZairMahmood 