### PR TITLE
Don't check version on MysqlCheck initialize

### DIFF
--- a/lib/simple_health_check/mysql_check.rb
+++ b/lib/simple_health_check/mysql_check.rb
@@ -3,7 +3,7 @@ class SimpleHealthCheck::MysqlCheck < SimpleHealthCheck::BaseNoProc
     @service_name = service_name
     @proc = check_proc || SimpleHealthCheck::Configuration.mysql_check_proc
     @type = 'internal'
-    @version = version_check rescue nil
+    @version = nil
   end
 
   def call(response:)

--- a/lib/simple_health_check/version.rb
+++ b/lib/simple_health_check/version.rb
@@ -1,3 +1,3 @@
 module SimpleHealthCheck
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
- [x] @edk 

Updated so that we don't call version_check method when initializing MysqlCheck no matter what.

Tested locally and confirmed the output did not change if `@version` is nil on initialize. Might be fine to remove entirely, but I wanted to keep the pattern from 
https://github.com/coupa/simple_health_check/blob/4d86d8023584cc2ca8145b4a11b245ed331f8926/lib/simple_health_check/base.rb#L30