### PR TITLE
nil array fix

### DIFF
--- a/lib/simple_health_check/configuration.rb
+++ b/lib/simple_health_check/configuration.rb
@@ -25,8 +25,7 @@ module SimpleHealthCheck
           SimpleHealthCheck::VersionCheck
         ]
         added_checks = all_checks.map { |x| x if allowed_checks.include?(x.class) }
-        @simple_checks ||= added_checks | [SimpleHealthCheck::BasicStatus.new]
-        @simple_checks.compact
+        @simple_checks ||= added_checks.compact | [SimpleHealthCheck::BasicStatus.new]
       end
 
       def all_checks
@@ -34,7 +33,7 @@ module SimpleHealthCheck
         @all_checks ||= @checks.map do |c|
           c.is_a?(Class) ? c.new : c
         end
-        @all_checks.compact
+        @all_checks ||= @checks.compact
       end
 
       def add_check klass_or_instance

--- a/lib/simple_health_check/configuration.rb
+++ b/lib/simple_health_check/configuration.rb
@@ -26,6 +26,7 @@ module SimpleHealthCheck
         ]
         added_checks = all_checks.map { |x| x if allowed_checks.include?(x.class) }
         @simple_checks ||= added_checks | [SimpleHealthCheck::BasicStatus.new]
+        @simple_checks.compact
       end
 
       def all_checks
@@ -33,6 +34,7 @@ module SimpleHealthCheck
         @all_checks ||= @checks.map do |c|
           c.is_a?(Class) ? c.new : c
         end
+        @all_checks.compact
       end
 
       def add_check klass_or_instance


### PR DESCRIPTION
@edk 

nil was added somewhere inside the simple_check and all_check arrays which was causing throwing an unnecessary error in logs. Health check and detailed check still worked fine.

Fixed by compacting arrays to remove all nil objects inside