### PR TITLE
Fix flaky mysql connection check

### DIFF
--- a/lib/simple_health_check/mysql_check.rb
+++ b/lib/simple_health_check/mysql_check.rb
@@ -12,7 +12,9 @@ class SimpleHealthCheck::MysqlCheck < SimpleHealthCheck::BaseNoProc
     rescue
       @version = nil
     end
-    super { ActiveRecord::Base.connected? }
+    super do
+      ActiveRecord::Base.connection_pool.with_connection { |con| con.active? } rescue false
+    end
   end
 
   def version_check


### PR DESCRIPTION
Mysql check is flaky when checked for. Currently it only checks to see ActiveRecord is connected too. This may not be case always.

Instead look at the connection pool and find an active connection

Tested in a deployed rails dev server.
`ActiveRecord::Base.connected?` returned false
`ActiveRecord::Base.connection_pool.with_connection { |con| con.active? } rescue false` returned true
then `ActiveRecord::Base.connected?` returned true

@edk 