### PR TITLE
CD-161982 master: add statsd gauge check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ The class, or in some cases, an instance can also be passed in.
 Simple checks:
 * `SimpleHealthCheck::BasicStatusCheck` - returns "status": 1
 * `SimpleHealthCheck::VersionCheck` - reads from "VERSION" file. Change filename with `SimpleHealthCheck::Configuration.version_file = Rails.root.join('VERSION')`
+* `SimpleHealthCheck::StatsDStatusCheck` - calls statsd.gauge with a value 1. Can be used in cases where the return value of the health check is not monitored.  The gauge name, additional tags, and minimum time in minutes allowed between
+statsd calls (calls to the health check within that interval will not update the gauge) are provided when the check is registered.  In the example the minimum time between setting the gauge is 1 minute,
+the gauge name 'service_health', and version '1.2' as a tag.  The check returns `'pushed statsd': true` if called outside of the set minimum interval, `'pushed statsd': false` if called before the interval has elapsed.
+```
+SimpleHealthCheck::Configuration.configure do |config|
+   config.add_check SimpleHealthCheck::StatsDStatusCheck.new(interval: 1, key_name: 'service_health', tags: ['version: 1.2'])
+end
+```
 
 * `SimpleHealthCheck::JsonFile` - much like the `VersionCheck`, however it reads a static json file and injects it into the returned status.
 

--- a/lib/simple_health_check.rb
+++ b/lib/simple_health_check.rb
@@ -12,6 +12,7 @@ module SimpleHealthCheck
     resque_check
     scheduler_check
     s3_check
+    stats_d_status_check
     version_check
     version
   ].each do |file|

--- a/lib/simple_health_check/configuration.rb
+++ b/lib/simple_health_check/configuration.rb
@@ -22,7 +22,8 @@ module SimpleHealthCheck
       def simple_checks
         allowed_checks = [
           SimpleHealthCheck::JsonFile,
-          SimpleHealthCheck::VersionCheck
+          SimpleHealthCheck::VersionCheck,
+          SimpleHealthCheck::StatsDStatusCheck
         ]
         added_checks = all_checks.map { |x| x if allowed_checks.include?(x.class) }
         @simple_checks ||= added_checks.compact | [SimpleHealthCheck::BasicStatus.new]

--- a/lib/simple_health_check/stats_d_status_check.rb
+++ b/lib/simple_health_check/stats_d_status_check.rb
@@ -1,0 +1,30 @@
+# Pass in interval (minimum time in minutes between statsd calls pushing out status)
+# pass in key_name and tags array to be used in statsd gauge
+class SimpleHealthCheck::StatsDStatusCheck < SimpleHealthCheck::Base
+  class << self
+    @service_status_last_push = nil
+
+    def try_push_status(interval, key_name, tags)
+      last_push_time = @service_status_last_push
+      current_time = Time.now
+      if last_push_time.nil? || last_push_time < current_time - interval
+        @service_status_last_push = current_time
+        StatsD.gauge(key_name, 1, tags: tags)
+        return true
+      end
+      false
+    end
+  end
+
+  def initialize(interval: 5, key_name:, tags:)
+    @interval = interval.minutes
+    @key_name = key_name
+    @tags = tags
+  end
+
+  def call(response:)
+    result = self.class.try_push_status(@interval, @key_name, @tags)
+    response.add name: 'pushed statsd', status: result
+    response
+  end
+end

--- a/lib/simple_health_check/version.rb
+++ b/lib/simple_health_check/version.rb
@@ -1,3 +1,3 @@
 module SimpleHealthCheck
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end

--- a/simple_health_check.gemspec
+++ b/simple_health_check.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "statsd-instrument", "~> 2.2.1"
 end


### PR DESCRIPTION
- [x] @edk

 Add health check task to report to statsd that application is available by setting a gauge value to 1.  
This check is also added to the allowed simple checks so that availability statistics and alerts can be configured based on the gauge.  


cc: @alcima-coupa , @latifsiddiquicoupa 

