### PR TITLE
Added AsyncHttpEndpointCheck 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ for an example where multiple fields and types can be set on failure.
 Same as the `SimpleHealthCheck::GenericCheck` but will also be executed by the `/health` action.
 It should only be used for light-weight checks that will return immediately.
 
+* `SimpleHealthCheck::AsyncHttpEndpointCheck` - This does the health checks of http endpoints passed to it in an asynchronous way. Pass an array of endpoints that must be health checked.
+
 Derive new checks from `SimpleHealthCheck::Base` and write the `call` method.
 
 The `/health` action returns an http code (:ok, or other code as determined by a check result).  In a Rails app,
@@ -65,8 +67,7 @@ cause the container to get killed.  Whether or not you'd want this depends on yo
 with the `hard_fail:` option.
 The `/health` action will only execute checks of type `SimpleHealthCheck::BasicStatus`, SimpleHealthCheck::JsonFile`,`SimpleHealthCheck::VersionCheck` and `SimpleHealthCheck::SimpleGenericCheck`.
 All registered checks will be executes by the `/health/detailed` action.
-                                                                
-                                                                
+                                                                                                                             
 
 ## Contributing
 

--- a/lib/simple_health_check/async_http_endpoint_check.rb
+++ b/lib/simple_health_check/async_http_endpoint_check.rb
@@ -1,0 +1,51 @@
+# Usage:
+# SimpleHealthCheck::AsyncHttpEndpointCheck.new(
+#   [ 
+#     {
+#       name: 'abc',
+#       hostname: lambda { Setup.lookup('test_hostname') },
+#       enabled: lambda { Setup.key_enabled? },
+#       health_path: '/health'
+#     },
+#     {
+#       name: 'test',
+#       hostname: 'abc-test.coupahost.com',
+#       enabled: true,
+#       health_path: '/v1/health'
+#     }
+#   ]
+# ).call
+
+class SimpleHealthCheck::AsyncHttpEndpointCheck < SimpleHealthCheck::Base
+  # config is an array of hashes with the service names and http endpoints
+  def initialize(config: [])
+    @initial_configs = config.map(&:symbolize_keys)
+  end
+
+  def call(response:)
+    # Refer: https://guides.rubyonrails.org/threading_and_code_execution.html
+    Rails.application.executor.wrap do
+      @configs = @initial_configs.select { |c| c[:enabled].respond_to?(:call) ? c[:enabled].call : c[:enabled] }
+      futures = @configs.collect do |config|
+        hostname = config[:hostname].respond_to?(:call) ? config[:hostname].call : config[:hostname]
+        url = "#{hostname}#{config[:health_path]}"
+        Concurrent::Future.execute do
+          Rails.application.executor.wrap do
+            obj = SimpleHealthCheck::HttpEndpointCheck.new(service_name: config[:name], url: url)
+            {
+              http_endpoint_obj: obj,
+              response: obj.call(response: response)
+            }
+          end # executor.wrap
+        end # Concurrent::Future.execute
+      end # collect
+
+      ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+        overall_responses = futures.collect(&:value)
+        response.overall_status = overall_responses.all? {|a| a[:response][0] == :ok } ? :ok : :crit
+        overall_responses
+      end # interlock.permit_concurrent_loads
+    end # executor.wrap
+
+  end
+end

--- a/lib/simple_health_check/http_endpoint_check.rb
+++ b/lib/simple_health_check/http_endpoint_check.rb
@@ -1,5 +1,6 @@
 # Useful for checking other service's health check endpoint
 class SimpleHealthCheck::HttpEndpointCheck < SimpleHealthCheck::BaseNoProc
+  DEFAULT_OPEN_TIMEOUT = 30 # Default is 60 secs. Currently setting it to 30. Set it to lower/higher value if required.
   def initialize(service_name: 'http_endpoint', check_proc: nil, url: nil)
     @service_name = service_name
     @proc = check_proc || SimpleHealthCheck::Configuration.http_endpoint_check_proc
@@ -12,6 +13,7 @@ class SimpleHealthCheck::HttpEndpointCheck < SimpleHealthCheck::BaseNoProc
       uri = URI(@url)
       raise "Host is nil! Please pass a valid http endpoint." if uri.host.nil?
       http = Net::HTTP.new(uri.host, uri.port)
+      http.open_timeout = DEFAULT_OPEN_TIMEOUT
       http.use_ssl = true if @url.include?('https')
       request = Net::HTTP::Get.new(uri)
       resp = http.request(request)

--- a/lib/simple_health_check/memcache_check.rb
+++ b/lib/simple_health_check/memcache_check.rb
@@ -17,7 +17,7 @@ class SimpleHealthCheck::MemcacheCheck < SimpleHealthCheck::BaseNoProc
       raise "Please pass the memcache config correctly" if @memcache_servers.empty? || @memcache_servers.any? {|server| server.split(':').length == 1}
 
       dalli_client = ::Dalli::Client.new(@memcache_servers)
-      @version = dalli_client.version&.values rescue nil
+      @version = dalli_client.version&.values.first rescue nil
       dalli_client.alive!
     end
   end


### PR DESCRIPTION
## Summary of issue

`SimpleHealth::HttpEndpointCheck` checks the health of a given microservice. If we want to do a health check of say some 10 services, then we should do it sequentially using `SimpleHealth::HttpEndpointCheck`

## Summary of change

Added `SimpleHealth::AsyncHttpEndpointCheck` that takes in an array of microservices and does the healthcheck of them in an async manner using `Concurrent::Future` gem.

## Reviewers

-  [x] @edk 

cc @tjackiw 

